### PR TITLE
Abbreviations overhaul

### DIFF
--- a/JSON_files/gear.JSON
+++ b/JSON_files/gear.JSON
@@ -240,7 +240,7 @@
         "artifact": 10 // Augmented
       }
     },
-    "MK10 Indomitus": {
+    "MK10 Tacticus": {
       "armour_value": {
         "standard": 24,
         "master_crafted": 26, // Augmented

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -587,62 +587,27 @@ function scr_ui_manage() {
 		            ar_mb=0;
 		            //TODO handle recursively
 					if (ma_armour[sel]!=""){
-						ma_ar=scr_wep_abbreviate(ma_armour[sel]);// vehicle weapon 3
-						if (string_count("^",ma_armour[sel])>0){
-							ar_ar=1;
-							ma_ar=string_replace(ma_ar,"^","");
-						}
-						if (string_count("&",ma_armour[sel])>0){
-							ar_ar=2;
-							ma_ar="Artifact";
-						}
+						ma_ar=gear_weapon_data("weapon",ma_armour[sel],"abbreviation");
+						ma_ar=is_string(ma_ar) ? ma_ar : "";
 					}
 					if (ma_gear[sel]!=""){
-						ma_ge=scr_wep_abbreviate(ma_gear[sel]);// vehicle upgrade
-						if (string_count("^",ma_gear[sel])>0){
-							ar_ge=1;
-							ma_ge=string_replace(ma_ge,"^","");
-						}
-						if (string_count("&",ma_gear[sel])>0){
-							ar_ge=2;
-							ma_ge="Artifact";
-						}
+						ma_ge=gear_weapon_data("armour",ma_gear[sel],"abbreviation");
+						ma_ge=is_string(ma_ge) ? ma_ge : ""	;		
 					}
 					if (ma_mobi[sel]!=""){
-						ma_mb=scr_wep_abbreviate(ma_mobi[sel]);// vehicle accessory
-						if (string_count("^",ma_mobi[sel])>0){
-							ar_mb=1;
-							ma_mb=string_replace(ma_mb,"^","");
-						}
-						if (string_count("&",ma_mobi[sel])>0){
-							ar_mb=2;
-							ma_mb="Artifact";
-						}
-					}
+						ma_mb=gear_weapon_data("gear",ma_mobi[sel],"abbreviation");
+						ma_mb=is_string(ma_mb) ? ma_mb : ""	;			            	
+		            }
 					if (ma_wep1[sel]!=""){
-						ma_we1=scr_wep_abbreviate(ma_wep1[sel]);//vehicle weapon 1
-						if (string_count("^",ma_wep1[sel])>0){
-							ar_we1=1;
-							ma_we1=string_replace(ma_we1,"^","");
-						}
-						if (string_count("&",ma_wep1[sel])>0){
-							ar_we1=2;
-							ma_we1="Artifact";
-						}
+						ma_we1=gear_weapon_data("weapon",ma_wep1[sel],"abbreviation");
+						ma_we1=is_string(ma_we1) ? ma_we1 : "";			            	
 					}
 					if (ma_wep2[sel]!=""){
-						ma_we2=scr_wep_abbreviate(ma_wep2[sel]);//vehicle weapon 2
-						if (string_count("^",ma_wep2[sel])>0){
-							ar_we2=1;
-							ma_we2=string_replace(ma_we2,"^","");
-						}
-						if (string_count("&",ma_wep2[sel])>0){
-							ar_we2=2;
-							ma_we2="Artifact";
-						}
+						ma_we2=gear_weapon_data("weapon",ma_wep2[sel],"abbreviation");
+						ma_we2=is_string(ma_we1) ? ma_we2 : "";	
+						// temp5=string(ma_wep1[sel])+", "+string(ma_wep2[sel])+" + "+string(ma_gear[sel]);
+		      }
 					}
-		            // temp5=string(ma_wep1[sel])+", "+string(ma_wep2[sel])+" + "+string(ma_gear[sel]);
-		        }
 
 		        if (man_sel[sel]==0) then draw_set_color(c_black);
 		        if (man_sel[sel]!=0) then draw_set_color(6052956);// was gray

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1365,6 +1365,7 @@ global.gear = {
       "melee_hands":2,
       "ranged_hands":2,
       "description": "The toughest and most powerful armour designed by humanity. Only the most veteran of Astartes are allowed to wear these.",
+      "tags":["terminator"],
       "req_exp":90,
     },
     "Dreadnought": {
@@ -1431,6 +1432,7 @@ global.gear = {
       "melee_hands":2,
       "ranged_hands":2,      
       "description": "Among the first issued to the Space Marine Legions, it is functionally distinct from other patterns, bearing additional plating and shield generators installed within the shoulder pads",
+      "tags":["terminator"],
       "req_exp":90,
     },
      "Ork Armour": {

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1736,7 +1736,7 @@ global.gear = {
     },    
     "Narthecium": {
     "abbreviation": "Nrthcm",
-      "special_description": "Medical field kit",
+      "special_description": "Heals Allies",
       "description": "An advanced medical field kit, these allow Space Marines to heal or recover Gene-Seed from fallen marines.",
         "melee_hands": -0.5,
         "ranged_hands": -0.5,       

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -442,7 +442,7 @@ global.weapons={
         "tags":["power","dual","fist"],
     },
     "Dreadnought Lightning Claw": {
-    "abbreviation": "DrdLghtClaw",             
+    "abbreviation": "LghtClaw",             
         "attack": {
             "standard": 300,
             "master_crafted": 400,
@@ -506,7 +506,7 @@ global.weapons={
         "tags":["arcane"],
     },
     "Relic Blade": {
-      "abbreviation": "RlcBlade",               
+      "abbreviation": "RlcBld",               
         "attack": {
             "standard": 700,
             "master_crafted": 850,
@@ -607,7 +607,7 @@ global.weapons={
         "tags":["bolt"]
     },
     "Heavy Flamer": {
-        "abbreviation": "HvyFlmer",              
+        "abbreviation": "HvyFlmr",              
         "attack": {
             "standard": 500,
             "master_crafted": 550,
@@ -623,7 +623,7 @@ global.weapons={
         "tags":["flame","heavy_ranged"]
     },
     "CCW Heavy Flamer": {
-        "abbreviation": "CCWHvyFlmer",               
+        "abbreviation": "CCWHvyFlmr",               
         "attack": {
             "standard": 250,
             "master_crafted": 275,
@@ -639,7 +639,7 @@ global.weapons={
         "tags":["dreadnought","flame"]
     },
     "Dreadnought Power Claw":{
-      "abbreviation": "DrdPwrClaw",              
+      "abbreviation": "PwrClaw",              
         "attack": {
             "standard": 400,
             "master_crafted": 600,
@@ -1135,7 +1135,7 @@ global.weapons={
             "artifact": 660
         },
         "description": "A much larger and bulkier flamer. Few armies carry them on hand, instead choosing to mount them to vehicles.",
-        "abbreviation": "TwnHvyFlmers", 
+        "abbreviation": "TwnHvyFlmrs", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 12,
@@ -1195,7 +1195,7 @@ global.weapons={
         "description": "",
     },  
     "Heavy Flamer Sponsons": {
-        "abbreviation": "HvyFlmers", 
+        "abbreviation": "HvyFlmrs", 
         "description": "",
     },  
     "Volkite Culverin Sponsons": {
@@ -1203,7 +1203,7 @@ global.weapons={
         "description": "",
     },  
     "Autocannon Turret": {
-        "abbreviation": "AutoCanTrt", 
+        "abbreviation": "Autocnn", 
         "attack": {
             "standard": 130,
             "master_crafted": 528,
@@ -1219,7 +1219,7 @@ global.weapons={
         "tags":["vehicle", "turrent"]
     },     
     "Storm Bolter": {
-        "abbreviation": "StrmBolt", 
+        "abbreviation": "StrmBltr", 
         "attack": {
             "standard": 80,
             "master_crafted": 88,
@@ -1235,7 +1235,7 @@ global.weapons={
         "tags":["bolt"]
     },
     "Flamer": {
-        "abbreviation": "Flmer", 
+        "abbreviation": "Flmr", 
         "attack": {
             "standard": 350,
             "master_crafted": 385,
@@ -1262,7 +1262,7 @@ global.weapons={
             "artifact": 240
         },
         "description": "",
-        "abbreviation": "UndrFlmer", 
+        "abbreviation": "UndrFlmr", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 4,
@@ -1272,7 +1272,7 @@ global.weapons={
         "tags":["flame"]
     },
     "Combiflamer": {
-        "abbreviation": "CmbFlmer", 
+        "abbreviation": "CmbFlmr", 
         "attack": {
             "standard": 100,
             "master_crafted": 130,
@@ -1325,7 +1325,7 @@ global.weapons={
             "master_crafted": 300,
             "artifact": 350
         },
-        "abbreviation": "TwnLscnnTrrt", 
+        "abbreviation": "TwnLscnn", 
         "description": "A Predator-compatible turret mounting a pair of anti-armour lascannons.",
         "range": 1,
         "spli": 0,

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1408,7 +1408,7 @@ global.gear = {
       "melee_hands":2,
       "ranged_hands":2,      
       "description": "Even more advanced than the Indomitus Terminator Armour, this upgraded armour offers greater mobility at no cost to protection.",
-      "tags":["teminator"],
+      "tags":["terminator"],
     },
     "Cataphractii Pattern Terminator":{
         "abbreviation": "Catph", 
@@ -1430,7 +1430,7 @@ global.gear = {
       "melee_hands":2,
       "ranged_hands":2,      
       "description": "Among the first issued to the Space Marine Legions, it is functionally distinct from other patterns, bearing additional plating and shield generators installed within the shoulder pads",
-        "tags":["teminator"],
+        "tags":["terminator"],
     },
      "Ork Armour": {
      "abbreviation": "OrkArm", 

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -129,6 +129,7 @@ global.weapons={
             "artifact": 140
         },
         "description": "Known as a Lasrod or Gelt Gun, this pistol is an ancient design of Laspistol with much greater range and power.",
+        "abbreviation": "ArchLpstl",
         "melee_hands": 0,
         "ranged_hands": 1,
         "ammo": 0,
@@ -383,7 +384,7 @@ global.weapons={
         "tags":["power", "axe", "dual"],
     },
     "Executioner Power Axe": {
-       "abbreviation": "ExPoAxe",       
+       "abbreviation": "ExPwrAxe",       
         "attack": {
             "standard": 300,
             "master_crafted": 350,
@@ -526,7 +527,7 @@ global.weapons={
          "tags":["arcane", "sword"],
     },
     "Bolt Pistol": {
-         "abbreviation": "BoltPist",               
+         "abbreviation": "BltPstl",               
         "attack": {
             "standard": 30,
             "master_crafted": 35,
@@ -558,7 +559,7 @@ global.weapons={
         "tags":["immobolise"]
     },
     "Underslung Bolter": {
-        "abbreviation": "UsBolt",            
+        "abbreviation": "UndBltr",            
         "attack": {
             "standard": 60,
             "master_crafted": 70,
@@ -574,7 +575,7 @@ global.weapons={
          "tags":["bolt", "attached"]
     },
     "Stalker Pattern Bolter": {
-        "abbreviation": "StlkBolt",            
+        "abbreviation": "StlkBltr",            
         "attack": {
             "standard": 100,
             "master_crafted": 110,
@@ -590,7 +591,7 @@ global.weapons={
         "tags":["bolt","precision"]
     },
     "Bolter": {
-        "abbreviation": "Bolter",             
+        "abbreviation": "Bltr",             
         "attack": {
             "standard": 50,
             "master_crafted": 55,
@@ -714,7 +715,7 @@ global.weapons={
         "tags":["melta","heavy_ranged", "dreadnought"]
     },
     "Plasma Pistol": {
-        "abbreviation": "PlsmPist",
+        "abbreviation": "PlsmPstl",
         "attack": {
             "standard": 115,
             "master_crafted": 130,
@@ -730,7 +731,7 @@ global.weapons={
         "tags":["plasma","pistol"]
     },
     "Infernus Pistol": {
-      "abbreviation": "InfPist" ,
+      "abbreviation": "InfPstl" ,
         "attack": {
             "standard": 100,
             "master_crafted": 110,
@@ -746,7 +747,7 @@ global.weapons={
         "tags":["flame","pistol"]
     },
     "Plasma Gun": {
-        "abbreviation": "PlsmGun",
+        "abbreviation": "PlsmGn",
         "attack": {
             "standard": 250,
             "master_crafted": 275,
@@ -762,7 +763,7 @@ global.weapons={
         "tags":["plasma"]
     },
     "Sniper Rifle": {
-        "abbreviation": "Snipe",        
+        "abbreviation": "SnprRfl",        
         "attack": {
             "standard": 80,
             "master_crafted": 88,
@@ -794,7 +795,7 @@ global.weapons={
         "tags":["heavy_ranged","dreadnought"]
     },
     "Autocannon": {
-        "abbreviation": "AutoCann",       
+        "abbreviation": "Autocnn",       
         "attack": {
             "standard": 180,
             "master_crafted": 198,
@@ -826,7 +827,7 @@ global.weapons={
         "tags":["heavy_ranged","dreadnought"]
     },
     "Lascannon": {
-       "abbreviation": "Lscnn",           
+       "abbreviation": "Lascnn",           
         "attack": {
             "standard": 200,
             "master_crafted": 220,
@@ -857,7 +858,7 @@ global.weapons={
         "arp": 1
     },
     "Integrated Bolters": {
-        "abbreviation": "IntBolt", 
+        "abbreviation": "IntgBltr", 
         "attack": {
             "standard": 75,
             "master_crafted": 82.5,
@@ -873,7 +874,7 @@ global.weapons={
         "tags":["bolt"]
     },
     "Power Fist with Intergrated Bolters": {
-       "abbreviation": "PwrFstIntBlt",       
+       "abbreviation": "PwrFstBltr",       
         "attack": {
             "standard": 450,
             "master_crafted": 500,
@@ -910,7 +911,7 @@ global.weapons={
         "arp": 0
     },
     "Twin Linked Heavy Bolter": {
-        "abbreviation": "TwnHvyBolt", 
+        "abbreviation": "TwnHvyBltr", 
         "attack": {
             "standard": 240,
             "master_crafted": 264,
@@ -926,7 +927,7 @@ global.weapons={
         "tags":["heavy_ranged","vehicle","dreadnought"]
     },
     "Twin Linked Lascannon": {
-        "abbreviation": "TwnLascann", 
+        "abbreviation": "TwnLascnn", 
         "attack": {
             "standard": 250,
             "master_crafted": 275,
@@ -942,7 +943,7 @@ global.weapons={
         "tags":["heavy_ranged","vehicle","dreadnought"]
     },
     "Lascannons": {
-         "abbreviation": "Lascanns", 
+         "abbreviation": "DblLascnn", 
         "attack": {
             "standard": 300,
             "master_crafted": 330,
@@ -958,7 +959,7 @@ global.weapons={
         "tags":["heavy_ranged","vehicle","dreadnought"]
     },
     "Heavy Bolter": {
-        "abbreviation": "HvyBolt", 
+        "abbreviation": "HvyBltr", 
         "attack": {
             "standard": 320,
             "master_crafted": 352,
@@ -999,6 +1000,7 @@ global.weapons={
             "artifact": 288
         },
         "description": "Twin-linked Heavy Bolters are an upgraded version of the standard Heavy Bolter weapon, which is known for its high rate of fire and effectiveness against infantry and light vehicles.",
+        "abbreviation": "TwnHvyBltr", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 20,
@@ -1013,6 +1015,7 @@ global.weapons={
             "artifact": 300
         },
         "description": "Lascannons are powerful anti-armour weapons that fire highly focused and devastating energy beams capable of penetrating even the toughest armour.",
+        "abbreviation": "TwnLascnn", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 10,
@@ -1027,6 +1030,7 @@ global.weapons={
             "artifact": 432
         },
         "description": "A twin mount of rotary autocannons, boasting an incredible rate of fire.",
+        "abbreviation": "TwnAssCnn", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 5,
@@ -1041,6 +1045,7 @@ global.weapons={
             "artifact": 300
         },
         "description": "An archaic twin-linked autocannon design dating back to the Great Crusade. Effective against a variety of targets.",
+        "abbreviation": "RprAtcnn", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 25,
@@ -1055,6 +1060,7 @@ global.weapons={
             "artifact": 576
         },
         "description": "Quad-linked Heavy Bolters are a significantly upgraded version of the standard Heavy Bolter mount; already punishing in a single mount, this quad mount is devastating against a variety of targets.",
+        "abbreviation": "QdHvyBltrs", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 10,
@@ -1069,6 +1075,7 @@ global.weapons={
             "artifact": 450
         },
         "description": "Lascannons are powerful anti-armour weapons that fire highly focused and devastating energy beams capable of penetrating even the toughest armour.",
+        "abbreviation": "TwnLascnns", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 5,
@@ -1083,6 +1090,7 @@ global.weapons={
             "artifact": 350
         },
         "description": "Lascannons are powerful anti-armour weapons that fire highly focused and devastating energy beams capable of penetrating even the toughest armour.",
+        "abbreviation": "Lscnns", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 5,
@@ -1097,6 +1105,7 @@ global.weapons={
             "artifact": 486
         },
         "description": "Hurricane Bolters are large hex-mount bolter arrays that are able to deliver a withering hail of anti-infantry fire at short ranges.",
+        "abbreviation": "HrrcnBltrs", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 20,
@@ -1111,6 +1120,7 @@ global.weapons={
             "artifact": 720
         },
         "description": "A huge vehicle-mounted flamethrower, the heat produced by this terrifying weapon can crack even armoured ceramite.",
+        "abbreviation": "FlmstrmCnns", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 6,
@@ -1125,6 +1135,7 @@ global.weapons={
             "artifact": 660
         },
         "description": "A much larger and bulkier flamer. Few armies carry them on hand, instead choosing to mount them to vehicles.",
+        "abbreviation": "TwnHvyFlmers", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 12,
@@ -1140,6 +1151,7 @@ global.weapons={
             "artifact": 180
         },
         "description": "A Twin-linked Bolter consists of two Bolter weapons mounted side by side, typically on a vehicle or a special weapon platform.",
+        "abbreviation": "TwnBltrs", 
         "melee_hands": 1,
         "ranged_hands": 2,
         "ammo": 30,
@@ -1147,7 +1159,7 @@ global.weapons={
         "spli": 1,
     },        
     "Twin Linked Multi-Melta Sponsons": {
-        "abbreviation": "TwnMltMeltSpns", 
+        "abbreviation": "TwnMltMelts", 
         "attack": {
             "standard": 450,
             "master_crafted": 495,
@@ -1163,7 +1175,7 @@ global.weapons={
         "tags":["vehicle", "Sponson", "melta"]
     },
     "Twin Linked Volkite Culverin Sponsons": {
-        "abbreviation": "TwnVlcCulvSpns", 
+        "abbreviation": "TwnVlkCulvs", 
         "attack": {
             "standard": 480,
             "master_crafted": 528,
@@ -1178,6 +1190,18 @@ global.weapons={
         "arp": 0,
         "tags":["vehicle", "Sponson", "volkite"]
     },
+    "Heavy Bolter Sponsons": {
+        "abbreviation": "HvyBltrs", 
+        "description": "",
+    },  
+    "Heavy Flamer Sponsons": {
+        "abbreviation": "HvyFlmers", 
+        "description": "",
+    },  
+    "Volkite Culverin Sponsons": {
+        "abbreviation": "VlkClvs", 
+        "description": "",
+    },  
     "Autocannon Turret": {
         "abbreviation": "AutoCanTrt", 
         "attack": {
@@ -1238,6 +1262,7 @@ global.weapons={
             "artifact": 240
         },
         "description": "",
+        "abbreviation": "UndrFlmer", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 4,
@@ -1270,6 +1295,7 @@ global.weapons={
             "artifact": 240
         },
         "description": "This flamer weapon includes special promethium and sacred oils. It is particularly effective against Daemons and their ilk.",
+        "abbreviation": "Incnrtr", 
         "melee_hands": 1,
         "ranged_hands": 1,
         "ammo": 4,
@@ -1284,6 +1310,7 @@ global.weapons={
             "master_crafted": 100,
             "artifact": 150
         },
+        "abbreviation": "FrcWpn", 
         "description": "An advanced, psychically-attuned close combat weapon that is only fully effective in the hands of a psyker.",
         "melee_hands": 1,
         "ranged_hands": 1,
@@ -1298,14 +1325,43 @@ global.weapons={
             "master_crafted": 300,
             "artifact": 350
         },
-        "description": "A Predator-compatible turret mounting a pair of anti-armour lascannons. ",
+        "abbreviation": "TwnLscnnTrrt", 
+        "description": "A Predator-compatible turret mounting a pair of anti-armour lascannons.",
         "range": 1,
         "spli": 0,
         "arp": 1,
         "range":20,
         "amm":10,
         "tags":["las", "twin_linked", "vehicle","turret"]
-    },   
+    },
+    "Twin Linked Assault Cannon Turret": {
+        "abbreviation": "TwnAssCnn", 
+        "description": "",
+    },  
+    "Flamestorm Cannon Turret": {
+        "abbreviation": "FlmstrmCnn", 
+        "description": "",
+    },  
+    "Magna-Melta Turret": {
+        "abbreviation": "MgnMlt", 
+        "description": "",
+    },  
+    "Plasma Destroyer Turret": {
+        "abbreviation": "PlsmDestr", 
+        "description": "",
+    },  
+    "Heavy Conversion Beamer Turret": {
+        "abbreviation": "HvyCnvBmr", 
+        "description": "",
+    },  
+    "Neutron Blaster Turret": {
+        "abbreviation": "NtrnBlstr", 
+        "description": "",
+    },  
+    "Volkite Saker Turret": {
+        "abbreviation": "VlkSkr", 
+        "description": "",
+    },
 }
 
 global.gear = {
@@ -1331,7 +1387,7 @@ global.gear = {
       "tags":["power_armour"],
     },
     "Artificer Armour": {
-        "abbreviation": "Arti", 
+        "abbreviation": "ArtArm", 
       "armour_value": {
         "standard": 30,
         "master_crafted": 34,
@@ -1351,7 +1407,7 @@ global.gear = {
       "tags":["power_armour"],
     },
     "Terminator Armour": {
-         "abbreviation": "Term", 
+         "abbreviation": "Termntr", 
       "armour_value": {
         "standard": 42,
         "master_crafted": 46,
@@ -1395,7 +1451,7 @@ global.gear = {
       "description": "A massive war-machine that can be piloted by an honored Space Marine, who otherwise would have fallen in combat."
     },
     "Tartaros": {
-        "abbreviation": "Tart", 
+        "abbreviation": "Tartr", 
       "armour_value": {
         "standard": 42,
         "master_crafted": 46,
@@ -1637,7 +1693,7 @@ global.gear = {
         },                   
     },    
     "Armoured Ceramite":{
-        "abbreviation": "ArmCeri",
+        "abbreviation": "ArmCrmt",
         "description": "Supplemental ceramite armour packages provide protection far beyond stock configurations",
          "armour_value": {
             "standard": 20,
@@ -1657,7 +1713,7 @@ global.gear = {
         "tags":["vehicle","armour"],              
     },
     "Artificer Hull":{
-        "abbreviation": "ArtfHll",
+        "abbreviation": "ArtHll",
         "description": "Replacing numerous structural members and armour plates with thrice-blessed replacements, the vehicle’s hull is upgraded to be a rare work of mechanical art.",
          "armour_value": {
             "standard": 10,
@@ -1669,6 +1725,7 @@ global.gear = {
 } , 
   "gear": {
     "Bionics": {
+        "abbreviation": "Bncs",
       "special_description": "Restores critical health",
       "description": "Bionics may be given to wounded marines to quickly get them back into combat-ready status, replacing damaged flesh.",
       "hp_mod": {
@@ -1725,6 +1782,7 @@ global.gear = {
       "description": "A special plasma charge, this bomb can be used to seal underground caves or destroy enemy structures.",
     },
     "Exterminatus": {
+        "abbreviation": "Extrmnts",
       "special_description": "Destroys planets",
       "description": "A weapon of the Emperor, and His divine judgment, this weapon can be placed upon a planet to obliterate it entirely.",
     },
@@ -1745,18 +1803,25 @@ global.gear = {
     "Smoke Launchers": {
       "special_description": "",
       "description": "Useful for providing concealment in open terrain, these launchers project wide-spectrum concealing smoke to prevent accurate targeting of the vehicle. ",
+      "abbreviation": "SmkLnchrs",
       "tags":["smoke","conceal"]
     },
     "Dozer Blades": {
       "special_description": "",
       "description": "An attachment for the front of vehicles, useful for clearing difficult terrain and can be used as an improvised weapon. ",
+      "abbreviation": "DzrBlds",
       "tags":[]
     },
     "Searchlight": {
       "special_description": "",
       "description": "A simple solution for fighting in dark environments, searchlights serve to illuminate enemies for easier targeting. ",
+      "abbreviation": "SrchLght",
       "tags":[]
-    },            
+    },
+    "Frag Assault Launchers": {
+        "abbreviation": "FrgAssLnchrs", 
+        "description": "",
+    },             
   },
   "mobility":{
    "Bike": {
@@ -1794,7 +1859,7 @@ global.gear = {
       "tags":["jump"],
     },
     "Heavy Weapons Pack": {
-    "abbreviation": "HvyWPck",
+    "abbreviation": "HvyWpPck",
       "description": "A heavy ammunition backpack commonly used by devastators in conjunction with a heavy ranged weapon.",
       "ranged_mod": {
         "standard": 5,

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -980,6 +980,7 @@ global.weapons={
             "artifact": 480
         },
         "description": "The Whirlwind Missile Launcher is a vehicle-mounted artillery weapon that launches a barrage of powerful missiles at the enemy.",
+        "abbreviation": "WhrlMssl", 
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 6,
@@ -987,6 +988,10 @@ global.weapons={
         "spli": 1,
         "arp": 1
     },
+    "HK Missile": {
+        "abbreviation": "HKMssl", 
+        "description": "",
+    },  
     "Twin Linked Heavy Bolter Mount": {
         "attack": {
             "standard": 240,

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -826,7 +826,7 @@ global.weapons={
         "tags":["heavy_ranged","dreadnought"]
     },
     "Lascannon": {
-       "abbreviation": "Lascann",           
+       "abbreviation": "Lscnn",           
         "attack": {
             "standard": 200,
             "master_crafted": 220,
@@ -842,7 +842,7 @@ global.weapons={
          "tags":["heavy_ranged"]
     },
     "Conversion Beam Projector": {
-        "abbreviation": "CBP",            
+        "abbreviation": "CnvBmPrj",            
         "attack": {
             "standard": 500,
             "master_crafted": 550,

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1365,7 +1365,7 @@ global.gear = {
       "melee_hands":2,
       "ranged_hands":2,
       "description": "The toughest and most powerful armour designed by humanity. Only the most veteran of Astartes are allowed to wear these.",
-       "tags":["terminator"],
+      "req_exp":90,
     },
     "Dreadnought": {
          "abbreviation": "Dread", 
@@ -1409,6 +1409,7 @@ global.gear = {
       "ranged_hands":2,      
       "description": "Even more advanced than the Indomitus Terminator Armour, this upgraded armour offers greater mobility at no cost to protection.",
       "tags":["terminator"],
+      "req_exp":90,
     },
     "Cataphractii Pattern Terminator":{
         "abbreviation": "Catph", 
@@ -1430,7 +1431,7 @@ global.gear = {
       "melee_hands":2,
       "ranged_hands":2,      
       "description": "Among the first issued to the Space Marine Legions, it is functionally distinct from other patterns, bearing additional plating and shield generators installed within the shoulder pads",
-        "tags":["terminator"],
+      "req_exp":90,
     },
      "Ork Armour": {
      "abbreviation": "OrkArm", 

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1654,7 +1654,7 @@ global.gear = {
     "description": "The newest and most advanced of the standard mark power armours as such production has not yet reached maximum capacity creating a supply shortage.",
     "tags":["power_armour"],
     },
-    "MK10 Indomitus": {
+    "MK10 Tacticus": {
         "abbreviation": "MK10",
       "armour_value": {
         "standard": 24,
@@ -1671,7 +1671,7 @@ global.gear = {
         "master_crafted": 5, // Augmented
         "artifact": 10 // Augmented
       },
-      "description": "The MK10 Indomitus is the most advanced pattern of power armour available to the Space Marines, featuring advanced materials and systems.",
+      "description": "The MK10 Tacticus is the most advanced pattern of power armour available to the Space Marines, featuring advanced materials and systems.",
       "tags":["power_armour"],
     }, 
     "Skitarii Armour":{

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1387,7 +1387,7 @@ global.gear = {
       "tags":["power_armour"],
     },
     "Artificer Armour": {
-        "abbreviation": "ArtArm", 
+        "abbreviation": "Artfcr", 
       "armour_value": {
         "standard": 30,
         "master_crafted": 34,
@@ -1407,7 +1407,7 @@ global.gear = {
       "tags":["power_armour"],
     },
     "Terminator Armour": {
-         "abbreviation": "Termntr", 
+         "abbreviation": "Indmts", 
       "armour_value": {
         "standard": 42,
         "master_crafted": 46,
@@ -1430,7 +1430,7 @@ global.gear = {
       "req_exp":90,
     },
     "Dreadnought": {
-         "abbreviation": "Dread", 
+         "abbreviation": "Drdnght", 
       "armour_value": {
         "standard": 50,
         "master_crafted": 55,
@@ -1451,7 +1451,7 @@ global.gear = {
       "description": "A massive war-machine that can be piloted by an honored Space Marine, who otherwise would have fallen in combat."
     },
     "Tartaros": {
-        "abbreviation": "Tartr", 
+        "abbreviation": "Tartrs", 
       "armour_value": {
         "standard": 42,
         "master_crafted": 46,
@@ -1474,7 +1474,7 @@ global.gear = {
       "req_exp":90,
     },
     "Cataphractii Pattern Terminator":{
-        "abbreviation": "Catph", 
+        "abbreviation": "Catphr", 
       "armour_value": {
         "standard": 42,
         "master_crafted": 46,
@@ -1516,7 +1516,7 @@ global.gear = {
       "description": "Mismatched basic armour used by ork forces"
     },
     "Scout Armour": {
-    "abbreviation": "Scout",
+    "abbreviation": "SctArm",
       "armour_value": {
         "standard": 11,
         "master_crafted": 12,

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -873,7 +873,7 @@ global.weapons={
         "tags":["bolt"]
     },
     "Power Fist with Intergrated Bolters": {
-       "abbreviation": "PwrFistIntBolt",       
+       "abbreviation": "PwrFstIntBlt",       
         "attack": {
             "standard": 450,
             "master_crafted": 500,

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1664,7 +1664,7 @@ global.gear = {
 } , 
   "gear": {
     "Bionics": {
-      "special_description": "Restores critcal health",
+      "special_description": "Restores critical health",
       "description": "Bionics may be given to wounded marines to quickly get them back into combat-ready status, replacing damaged flesh.",
       "hp_mod": {
         "standard": 30, // Adjusted
@@ -1725,14 +1725,14 @@ global.gear = {
     },
     "Servo Arms": {
     "abbreviation": "SrvArms",
-      "special_description": "Integrated flamer, repairs",
+      "special_description": "Integrated Flamer, Repairs Vehicles",
       "description": "A pair of powerful, mechanical arms. They include several tools that allow trained marines to repair vehicles rapidly.",
         "melee_hands": 0.25,
         "ranged_hands": 0.25,  
     },
     "Master Servo Arms": {
     "abbreviation": "MsSrvArms",
-      "special_description": "Integrated flamer, repairs",
+      "special_description": "Integrated Flamer, Repairs Vehicles",
       "description": "This master servo harness includes additional mechanical arms and tools, allowing a greater capacity and rate of repairs.",
         "melee_hands": 0.25,
         "ranged_hands": 0.25,  
@@ -1756,7 +1756,7 @@ global.gear = {
   "mobility":{
    "Bike": {
     "abbreviation": "Bike",
-      "special_description": "",
+      "special_description": "Integrated Twin Linked-Bolters",
       "description": "A robust bike that can propel a marine at very high speeds. Boasts highly responsive controls and Twin Linked Bolters.",
       "hp_mod": {
         "standard": 25,
@@ -1774,7 +1774,7 @@ global.gear = {
 
     "Jump Pack": {
     "abbreviation": "JmpPck",
-      "special_description": "Jump Pack",
+      "special_description": "",
       "description": "A back-mounted device containing turbines or jets powerful enough to lift even a user in Power Armour.",
       "hp_mod": {
         "standard": 5,

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -54,7 +54,7 @@ global.weapons={
   },
   "Storm Shield": {
     "description":"Protects twice as well when boarding. A powered shield that must be held with a hand.  While powered by the marines armour it shimmers with blue energy.",
-    "abbreviation": "StShield",
+    "abbreviation": "StrmShld",
     "attack": {
       "standard": 5,
       "master_crafted": 5,
@@ -76,7 +76,7 @@ global.weapons={
   },
   "Boarding Shield": {
     "description":"Protects twice as well when boarding. Used in siege or boarding operations, this shield offers additional protection.  It may be used with a 2-handed ranged weapon.",    
-    "abbreviation": "BoShield",
+    "abbreviation": "BrdShld",
     "armour_value": {
         "standard": 4,
         "master_crafted": 5,
@@ -91,7 +91,7 @@ global.weapons={
     },        
   },
   "Hellgun": {
-    "abbreviation": "HGun",
+    "abbreviation": "HllGun",
     "attack": {
       "standard": 30,
       "master_crafted": 34,
@@ -108,7 +108,7 @@ global.weapons={
   },
   "Hellrifle": {
     "description":"Normally used by Radical Inquisitors, it appears an antiquated rifle but fires razor-sharp shards of Daemonic matter.",
-    "abbreviation": "HRifle",
+    "abbreviation": "HllRifle",
     "attack": {
       "standard": 150,
       "master_crafted": 160,
@@ -138,7 +138,7 @@ global.weapons={
         "tags":["pistol", "ancient","las"],
     },
     "Combat Knife": {
-        "abbreviation": "CmbtKni", 
+        "abbreviation": "CbKnf", 
         "attack": {
             "standard": 25,
             "master_crafted": 30,
@@ -169,7 +169,7 @@ global.weapons={
         "arp": 0
     },
     "Chainsword": {
-        "abbreviation": "ChSword",
+        "abbreviation": "ChSwrd",
         "attack": {
             "standard": 50,
             "master_crafted": 60,
@@ -206,7 +206,7 @@ global.weapons={
         "tags":["chain", "axe"],
     },
     "Company Standard": {
-       "abbreviation": "Stand",
+       "abbreviation": "CmpStnd",
       "special_description": "Boosts morale",
       "description": "A banner that represents the honor of a particular company and will bolster the morale abilities of nearby Space Marines.",
         "attack": {
@@ -247,7 +247,7 @@ global.weapons={
         "tags":["chain", "sword"],
     },
     "Power Sword": {
-         "abbreviation": "PoSword",
+         "abbreviation": "PwrSwrd",
         "attack": {
             "standard": 180,
             "master_crafted": 200,
@@ -269,7 +269,7 @@ global.weapons={
         "tags":["power", "sword"],
     },
     "Power Spear": {
-         "abbreviation": "PoSpear",
+         "abbreviation": "PwrSpear",
         "attack": {
             "standard": 200,
             "master_crafted": 250,
@@ -306,7 +306,7 @@ global.weapons={
         "tags":["power", "chain", "fist", "siege"],
     },
     "Lascutter": {
-       "abbreviation": "LCutter",
+       "abbreviation": "Lascttr",
         "attack": {
             "standard": 100,
             "master_crafted": 150,
@@ -319,7 +319,7 @@ global.weapons={
         "tags":["laser", "siege"],
     },    
     "Eldar Power Sword": {
-        "abbreviation": "EPoSword",
+        "abbreviation": "EldPwrSwrd",
         "attack": {
             "standard": 170,
             "master_crafted": 180,
@@ -341,7 +341,7 @@ global.weapons={
         "tags":["power", "sword","elder","xenos"],
     },
     "Power Weapon": {
-        "abbreviation": "PoWeap",
+        "abbreviation": "PwrWpn",
         "attack": {
             "standard": 135,
             "master_crafted": 145,
@@ -362,7 +362,7 @@ global.weapons={
         "tags":["power"],
     },
     "Power Axe": {
-       "abbreviation": "PoAxe",       
+       "abbreviation": "PwrAxe",       
         "attack": {
             "standard": 190,
             "master_crafted": 220,
@@ -404,7 +404,7 @@ global.weapons={
         "tags":["power", "axe"],
     },    
     "Power Fist": {
-       "abbreviation": "PoFist",       
+       "abbreviation": "PwrFist",       
         "attack": {
             "standard": 450,
             "master_crafted": 500,
@@ -425,7 +425,7 @@ global.weapons={
         "tags":["power","fist"],
     },
     "Lightning Claw": {
-    "abbreviation": "LiClaw",             
+    "abbreviation": "LghtClaw",             
         "attack": {
             "standard": 130,
             "master_crafted": 160,
@@ -441,7 +441,7 @@ global.weapons={
         "tags":["power","dual","fist"],
     },
     "Dreadnought Lightning Claw": {
-    "abbreviation": "DreadLiClaw",             
+    "abbreviation": "DrdLghtClaw",             
         "attack": {
             "standard": 300,
             "master_crafted": 400,
@@ -462,7 +462,7 @@ global.weapons={
         "tags":["power", "vehicle","dual","fist"],
     },
     "Thunder Hammer": {
-      "abbreviation": "THammer",                
+      "abbreviation": "ThndHmr",                
         "attack": {
             "standard": 650,
             "master_crafted": 750,
@@ -505,7 +505,7 @@ global.weapons={
         "tags":["arcane"],
     },
     "Relic Blade": {
-      "abbreviation": "Rblade",               
+      "abbreviation": "RlcBlade",               
         "attack": {
             "standard": 700,
             "master_crafted": 850,
@@ -526,7 +526,7 @@ global.weapons={
          "tags":["arcane", "sword"],
     },
     "Bolt Pistol": {
-         "abbreviation": "BoltPis",               
+         "abbreviation": "BoltPist",               
         "attack": {
             "standard": 30,
             "master_crafted": 35,
@@ -542,7 +542,7 @@ global.weapons={
         "tags":["bolt", "pistol"],
     },
     "Webber": {
-         "abbreviation": "Web",           
+         "abbreviation": "Webbr",           
         "attack": {
             "standard": 35,
             "master_crafted": 40,
@@ -558,7 +558,7 @@ global.weapons={
         "tags":["immobolise"]
     },
     "Underslung Bolter": {
-        "abbreviation": "USbolt",            
+        "abbreviation": "UsBolt",            
         "attack": {
             "standard": 60,
             "master_crafted": 70,
@@ -574,7 +574,7 @@ global.weapons={
          "tags":["bolt", "attached"]
     },
     "Stalker Pattern Bolter": {
-        "abbreviation": "SPatBolt",            
+        "abbreviation": "StlkBolt",            
         "attack": {
             "standard": 100,
             "master_crafted": 110,
@@ -590,7 +590,7 @@ global.weapons={
         "tags":["bolt","precision"]
     },
     "Bolter": {
-        "abbreviation": "Bolt",             
+        "abbreviation": "Bolter",             
         "attack": {
             "standard": 50,
             "master_crafted": 55,
@@ -606,7 +606,7 @@ global.weapons={
         "tags":["bolt"]
     },
     "Heavy Flamer": {
-        "abbreviation": "HvyFla",              
+        "abbreviation": "HvyFlmer",              
         "attack": {
             "standard": 500,
             "master_crafted": 550,
@@ -622,7 +622,7 @@ global.weapons={
         "tags":["flame","heavy_ranged"]
     },
     "CCW Heavy Flamer": {
-        "abbreviation": "CCWHvyFla",               
+        "abbreviation": "CCWHvyFlmer",               
         "attack": {
             "standard": 250,
             "master_crafted": 275,
@@ -638,7 +638,7 @@ global.weapons={
         "tags":["dreadnought","flame"]
     },
     "Dreadnought Power Claw":{
-      "abbreviation": "DreadPoCla",              
+      "abbreviation": "DrdPwrClaw",              
         "attack": {
             "standard": 400,
             "master_crafted": 600,
@@ -666,7 +666,7 @@ global.weapons={
         "tags":["dreadnought","fist"]
     },       
     "Inferno Cannon": {
-        "abbreviation": "InfeCan",               
+        "abbreviation": "InfCann",               
         "attack": {
             "standard": 400,
             "master_crafted": 440,
@@ -682,7 +682,7 @@ global.weapons={
         "tags":["vehicle","flame","dreadnought"]
     },
     "Meltagun": {
-        "abbreviation": "Melt",
+        "abbreviation": "Mltgn",
         "attack": {
             "standard": 250,
             "master_crafted": 275,
@@ -714,7 +714,7 @@ global.weapons={
         "tags":["melta","heavy_ranged", "dreadnought"]
     },
     "Plasma Pistol": {
-        "abbreviation": "PlasPis",
+        "abbreviation": "PlsmPist",
         "attack": {
             "standard": 115,
             "master_crafted": 130,
@@ -730,7 +730,7 @@ global.weapons={
         "tags":["plasma","pistol"]
     },
     "Infernus Pistol": {
-      "abbreviation": "InfPis" ,
+      "abbreviation": "InfPist" ,
         "attack": {
             "standard": 100,
             "master_crafted": 110,
@@ -746,7 +746,7 @@ global.weapons={
         "tags":["flame","pistol"]
     },
     "Plasma Gun": {
-        "abbreviation": "Plas",
+        "abbreviation": "PlsmGun",
         "attack": {
             "standard": 250,
             "master_crafted": 275,
@@ -778,7 +778,7 @@ global.weapons={
         "tags":["precision"]
     },
     "Assault Cannon": {
-        "abbreviation": "AsltCan",       
+        "abbreviation": "AssCann",       
         "attack": {
             "standard": 240,
             "master_crafted": 264,
@@ -794,7 +794,7 @@ global.weapons={
         "tags":["heavy_ranged","dreadnought"]
     },
     "Autocannon": {
-        "abbreviation": "AutCan",       
+        "abbreviation": "AutoCann",       
         "attack": {
             "standard": 180,
             "master_crafted": 198,
@@ -810,7 +810,7 @@ global.weapons={
         "tags":["heavy_ranged","dreadnought"]
     },
     "Missile Launcher": {
-      "abbreviation": "Missi",          
+      "abbreviation": "MsslLnch",          
         "attack": {
             "standard": 250,
             "master_crafted": 275,
@@ -826,7 +826,7 @@ global.weapons={
         "tags":["heavy_ranged","dreadnought"]
     },
     "Lascannon": {
-       "abbreviation": "LasCan",           
+       "abbreviation": "Lascann",           
         "attack": {
             "standard": 200,
             "master_crafted": 220,
@@ -873,7 +873,7 @@ global.weapons={
         "tags":["bolt"]
     },
     "Power Fist with Intergrated Bolters": {
-       "abbreviation": "PoFist IntBolt",       
+       "abbreviation": "PwrFistIntBolt",       
         "attack": {
             "standard": 450,
             "master_crafted": 500,
@@ -895,7 +895,7 @@ global.weapons={
         "tags":["power","fist"],
     },    
     "Power Fists": {
-        "abbreviation": "PowFists", 
+        "abbreviation": "PwrFists", 
         "attack": {
             "standard": 425,
             "master_crafted": 467.5,
@@ -910,7 +910,7 @@ global.weapons={
         "arp": 0
     },
     "Twin Linked Heavy Bolter": {
-        "abbreviation": "TL Hvy Bolt", 
+        "abbreviation": "TwnHvyBolt", 
         "attack": {
             "standard": 240,
             "master_crafted": 264,
@@ -926,7 +926,7 @@ global.weapons={
         "tags":["heavy_ranged","vehicle","dreadnought"]
     },
     "Twin Linked Lascannon": {
-        "abbreviation": "TL LasCan", 
+        "abbreviation": "TwnLascann", 
         "attack": {
             "standard": 250,
             "master_crafted": 275,
@@ -942,7 +942,7 @@ global.weapons={
         "tags":["heavy_ranged","vehicle","dreadnought"]
     },
     "Lascannons": {
-         "abbreviation": "LasCans", 
+         "abbreviation": "Lascanns", 
         "attack": {
             "standard": 300,
             "master_crafted": 330,
@@ -1142,7 +1142,7 @@ global.weapons={
         "spli": 1,
     },        
     "Twin Linked Multi-Melta Sponsons": {
-        "abbreviation": "TL MMelt Spons", 
+        "abbreviation": "TwnMltMeltSpns", 
         "attack": {
             "standard": 450,
             "master_crafted": 495,
@@ -1158,7 +1158,7 @@ global.weapons={
         "tags":["vehicle", "Sponson", "melta"]
     },
     "Twin Linked Volkite Culverin Sponsons": {
-        "abbreviation": "TL VolcCulv Spons", 
+        "abbreviation": "TwnVlcCulvSpns", 
         "attack": {
             "standard": 480,
             "master_crafted": 528,
@@ -1174,7 +1174,7 @@ global.weapons={
         "tags":["vehicle", "Sponson", "volkite"]
     },
     "Autocannon Turret": {
-        "abbreviation": "AutCanTur", 
+        "abbreviation": "AutoCanTrt", 
         "attack": {
             "standard": 130,
             "master_crafted": 528,
@@ -1190,7 +1190,7 @@ global.weapons={
         "tags":["vehicle", "turrent"]
     },     
     "Storm Bolter": {
-        "abbreviation": "StrmBlt", 
+        "abbreviation": "StrmBolt", 
         "attack": {
             "standard": 80,
             "master_crafted": 88,
@@ -1206,7 +1206,7 @@ global.weapons={
         "tags":["bolt"]
     },
     "Flamer": {
-        "abbreviation": "Flame", 
+        "abbreviation": "Flmer", 
         "attack": {
             "standard": 350,
             "master_crafted": 385,
@@ -1242,7 +1242,7 @@ global.weapons={
         "tags":["flame"]
     },
     "Combiflamer": {
-        "abbreviation": "ComFlame", 
+        "abbreviation": "CmbFlmer", 
         "attack": {
             "standard": 100,
             "master_crafted": 130,
@@ -1306,7 +1306,7 @@ global.weapons={
 global.gear = {
   "armour": {
     "Power Armour": {
-        "abbreviation": "PoArm", 
+        "abbreviation": "PwrArm", 
       "armour_value": {
         "standard": 19,
         "master_crafted": 25,
@@ -1326,7 +1326,7 @@ global.gear = {
       "tags":["power_armour"],
     },
     "Artificer Armour": {
-        "abbreviation": "ArtiPoArm", 
+        "abbreviation": "Arti", 
       "armour_value": {
         "standard": 30,
         "master_crafted": 34,
@@ -1346,7 +1346,7 @@ global.gear = {
       "tags":["power_armour"],
     },
     "Terminator Armour": {
-         "abbreviation": "Termi", 
+         "abbreviation": "Term", 
       "armour_value": {
         "standard": 42,
         "master_crafted": 46,
@@ -1389,7 +1389,7 @@ global.gear = {
       "description": "A massive war-machine that can be piloted by an honored Space Marine, who otherwise would have fallen in combat."
     },
     "Tartaros": {
-        "abbreviation": "Tarto", 
+        "abbreviation": "Tart", 
       "armour_value": {
         "standard": 42,
         "master_crafted": 46,
@@ -1411,7 +1411,7 @@ global.gear = {
       "tags":["teminator"],
     },
     "Cataphractii Pattern Terminator":{
-        "abbreviation": "Catii", 
+        "abbreviation": "Catph", 
       "armour_value": {
         "standard": 42,
         "master_crafted": 46,
@@ -1452,7 +1452,7 @@ global.gear = {
       "description": "Mismatched basic armour used by ork forces"
     },
     "Scout Armour": {
-    "abbreviation": "scout",
+    "abbreviation": "Scout",
       "armour_value": {
         "standard": 11,
         "master_crafted": 12,
@@ -1620,7 +1620,7 @@ global.gear = {
         },                   
     },
     "Dragon Scales":{
-        "abbreviation": "DraArm",
+        "abbreviation": "DrgnArm",
         "description": "advanced armour used by tech priests it is  remarkably lightweight for the protection it affords and is often greatly modified by it's wearer",
          "armour_value": {
             "standard": 12,
@@ -1639,7 +1639,7 @@ global.gear = {
         "tags":["vehicle","armour"],              
     },
     "Heavy Armour":{
-        "abbreviation": "Hvy Arm",
+        "abbreviation": "HvyArm",
         "description": "Simple but effective, extra armour plates can be attached to most vehicles to provide extra protection.",
          "armour_value": {
             "standard": 10,
@@ -1649,7 +1649,7 @@ global.gear = {
         "tags":["vehicle","armour"],              
     },
     "Artificer Hull":{
-        "abbreviation": "ArtiHull",
+        "abbreviation": "ArtfHll",
         "description": "Replacing numerous structural members and armour plates with thrice-blessed replacements, the vehicle’s hull is upgraded to be a rare work of mechanical art.",
          "armour_value": {
             "standard": 10,
@@ -1670,19 +1670,19 @@ global.gear = {
       }
     },    
     "Narthecium": {
-    "abbreviation": "Narth",
+    "abbreviation": "Nrthcm",
       "special_description": "Medical field kit",
       "description": "An advanced medical field kit, these allow Space Marines to heal or recover Gene-Seed from fallen marines.",
         "melee_hands": -0.5,
         "ranged_hands": -0.5,       
     },
     "Psychic Hood": {
-    "abbreviation": "PsyHood",
+    "abbreviation": "PsyHd",
       "special_description": "-50% chance of perils*",
       "description": "An arcane hood that protects Psykers from enemy psychic powers and enhances their control.",
     },
     "Rosarius": {
-        "abbreviation": "Rosa",
+        "abbreviation": "Rsrius",
       "special_description": "",
       "description": "Also called the 'Soul's Armour', this amulet has a built-in, powerful shield generator. They are an icon of the Imperial Creed.",
       "damage_resistance_mod": {
@@ -1721,13 +1721,14 @@ global.gear = {
       "description": "A weapon of the Emperor, and His divine judgment, this weapon can be placed upon a planet to obliterate it entirely.",
     },
     "Servo Arms": {
-    "abbreviation": "ServArm",
+    "abbreviation": "SrvArms",
       "special_description": "Integrated flamer, repairs",
       "description": "A pair of powerful, mechanical arms. They include several tools that allow trained marines to repair vehicles rapidly.",
         "melee_hands": 0.25,
         "ranged_hands": 0.25,  
     },
     "Master Servo Arms": {
+    "abbreviation": "MsSrvArms",
       "special_description": "Integrated flamer, repairs",
       "description": "This master servo harness includes additional mechanical arms and tools, allowing a greater capacity and rate of repairs.",
         "melee_hands": 0.25,
@@ -1769,7 +1770,7 @@ global.gear = {
     },
 
     "Jump Pack": {
-    "abbreviation": "JmpPack",
+    "abbreviation": "JmpPck",
       "special_description": "Jump Pack",
       "description": "A back-mounted device containing turbines or jets powerful enough to lift even a user in Power Armour.",
       "hp_mod": {
@@ -1785,7 +1786,7 @@ global.gear = {
       "tags":["jump"],
     },
     "Heavy Weapons Pack": {
-    "abbreviation": "HvyPack",
+    "abbreviation": "HvyWPck",
       "description": "A heavy ammunition backpack commonly used by devastators in conjunction with a heavy ranged weapon.",
       "ranged_mod": {
         "standard": 5,
@@ -1794,7 +1795,6 @@ global.gear = {
       },
     "melee_hands": -1,
     "ranged_hands": 1,      
-      "tags":["power"],
     }
     // Add more mobility items as needed...
   }

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1786,7 +1786,7 @@ global.gear = {
     },
     "Heavy Weapons Pack": {
     "abbreviation": "HvyPack",
-      "description": "A Heavy power pack commonly used by devastators in conjunction with a heavy ranged weapon.",
+      "description": "A heavy ammunition backpack commonly used by devastators in conjunction with a heavy ranged weapon.",
       "ranged_mod": {
         "standard": 5,
         "master_crafted": 10,


### PR DESCRIPTION
### Things that are done:
1. Changed ~90% of abbreviations. Main focus is to make them consistent, understandable and short.
2. Vehicle abbreviations support. Deprecate scr_wep_abbreviate?
3. A small amount of other small edits, like fixing missing tags on terminator armor, adding spec. descriptions to some items, fixing typos and so on.
4. "MK10 Indomitus" renamed into "MK10 Tacticus". This is potentially save breaking. Already existing MK10 suits will probably disappear.

### Things that are not done:
- [ ] Tweak abbreviations more?
	- [ ] Fist > Fst?
	- [ ] Frag Assault Launchers abbreviation is too long.
- [ ] Revert the MK10 rename?
	- [ ] In the future adding a separate item attribute that governs only displayed names may be beneficial, so that item names could be changed without breaking saves.

### Screenshots (under spoilers):

<details>
<summary>Before</summary>

![Before](https://github.com/OH296/ChapterMaster/assets/20323032/7b3295bc-194c-4f23-b7a2-7f99012dee44)

</details>

<details>
<summary>After</summary>

![After](https://github.com/OH296/ChapterMaster/assets/20323032/eb7b762b-1685-49d0-8308-fe7e4a7c08dd)

</details>