### PR TITLE
Some more UI edits

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -865,6 +865,7 @@
     {"id":{"name":"scr_audience","path":"scripts/scr_audience/scr_audience.yy",},},
     {"id":{"name":"spr_ba_mk7_helm","path":"sprites/spr_ba_mk7_helm/spr_ba_mk7_helm.yy",},},
     {"id":{"name":"spr_intelligence_icon","path":"sprites/spr_intelligence_icon/spr_intelligence_icon.yy",},},
+    {"id":{"name":"scr_truncate_string_width","path":"scripts/scr_truncate_string_width/scr_truncate_string_width.yy",},},
     {"id":{"name":"spr_dread_heavy_bolter","path":"sprites/spr_dread_heavy_bolter/spr_dread_heavy_bolter.yy",},},
     {"id":{"name":"spr_purity_seal","path":"sprites/spr_purity_seal/spr_purity_seal.yy",},},
     {"id":{"name":"scr_zoom","path":"scripts/scr_zoom/scr_zoom.yy",},},

--- a/objects/obj_drop_select/Step_0.gml
+++ b/objects/obj_drop_select/Step_0.gml
@@ -130,6 +130,7 @@ if (refresh_raid!=0){
                 if (obj_ini.role[comp][i]=obj_ini.role[100][2]) and (raid_vet=1){fighting[comp][i]=1;honor+=1;}
                 if (obj_ini.role[comp][i]=obj_ini.role[100][4]) and (raid_term=1){fighting[comp][i]=1;terminators+=1;}
                 if (obj_ini.role[comp][i]=obj_ini.role[100][5]) and (raid_vet=1){fighting[comp][i]=1;capts+=1;}
+                if (obj_ini.role[comp][i]="Company Champion") and (raid_vet=1){fighting[comp][i]=1;champions+=1;}
                 
                 if (obj_ini.role[comp][i]="Chapter Master") and (raid_spec=1){fighting[comp][i]=1;master=1;}
                 if (obj_ini.role[comp][i]="Master of Sanctity") and (raid_spec=1){fighting[comp][i]=1;chaplains+=1}

--- a/scripts/scr_draw_armentarium/scr_draw_armentarium.gml
+++ b/scripts/scr_draw_armentarium/scr_draw_armentarium.gml
@@ -3,7 +3,7 @@
 function drop_down_sandwich(selection, draw_x, draw_y, options, open_marker,left_text,right_text){
 	draw_text_transformed(draw_x, draw_y, left_text,1,1,0);
 	draw_x += string_width(left_text)+5;
-	var results = drop_down(selection, draw_x, draw_y, options,open_marker);
+	var results = drop_down(selection, draw_x, draw_y-2, options,open_marker);
     draw_set_color(c_gray);
 	draw_text_transformed(draw_x+9+ string_width(selection), draw_y, right_text,1,1,0);
     return results;
@@ -602,7 +602,7 @@ function scr_draw_armentarium(){
             y_offset,
             ["vehicles","wargear", "ships"],
             research_drop_down,
-            "research is currently focussed on", 
+            "Research is currently focussed on", 
             ".");
         research_drop_down = drop_down_results[1];
         stc_research.research_focus = drop_down_results[0]; 
@@ -808,7 +808,7 @@ function scr_draw_armentarium(){
         draw_text(xx+600,yy+109,string_hash_to_newline("Forge Points"));
         draw_text(xx+700,yy+109,string_hash_to_newline("Construction ETA"));        
         draw_set_color(c_gray);
-        var item_gap = 127;
+        var item_gap = 130;
         var total_eta=0;
         static top_point=0;
         for (var i=top_point; i<13; i++){

--- a/scripts/scr_truncate_string_width/scr_truncate_string_width.gml
+++ b/scripts/scr_truncate_string_width/scr_truncate_string_width.gml
@@ -1,0 +1,21 @@
+/// @function truncate_string_width(str, max_width)
+/// @description Truncates a string to fit within a specified pixel width, appending "..." if the string was truncated.
+/// @param {string} str The string to be truncated.
+/// @param {int} max_width The maximum allowable pixel width for the string.
+/// @returns {string} Original or truncated string.
+function truncate_string_width(str, max_width) {
+    var ellipsis = "...";
+    var ellipsis_width = string_width(ellipsis);
+    var str_width = string_width(str);
+    if (str_width > max_width) {
+        var i = string_length(str);
+        while (str_width + ellipsis_width > max_width && i > 0) {
+            i--;
+            str = string_delete(str, i+1, 1);
+            str_width = string_width(str);
+        }
+        return str + ellipsis;
+    } else {
+        return str;
+    }
+}

--- a/scripts/scr_truncate_string_width/scr_truncate_string_width.yy
+++ b/scripts/scr_truncate_string_width/scr_truncate_string_width.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "scr_truncate_string_width",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "Scripts",
+    "path": "folders/Scripts.yy",
+  },
+}

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -752,7 +752,7 @@ function scr_ui_manage() {
 				    	}
 			    	}
 		    	}
-		    	if (unit_specialism_option) then array_push(potential_tooltip, [spec_tip, [xx+25,yy+64,xx+250,yy+85]]);
+		    	if (unit_specialism_option) then array_push(potential_tooltip, [spec_tip, [xx+35.5,yy+64,xx+211.5,yy+85]]);
 
 		        // Squads
 		        var sqi="";
@@ -798,60 +798,50 @@ function scr_ui_manage() {
 				for (var k = 0; k<10; k++){
 					if ((string_width(string_hash_to_newline(temp1))*name_xr)>184-8) then name_xr-=0.05;
 				}
-	        
-		        if (temp1!="Chapter Master "+string(obj_ini.master_name)){
-					// Define text positions and values
-					var hpText = [xx+240+8, yy+66, string_hash_to_newline(string(temp3))]; // HP
-					var xpText = [xx+330+8, yy+66, string_hash_to_newline(string(temp4))]; // XP
-					// Define colors
-					var hpColor = c_gray;
-					var xpColor = c_gray;
-					// Check conditions and set colors
-					if (man[sel] == "man"){
-						if (ma_promote[sel] >= 10){
-							hpColor = c_red;
-							array_push(health_tooltip, ["Critical Health State! Bionic augmentation is required!", [xx+270, yy+64, xx+295, yy+85]]);
-						}else if (ma_promote[sel] > 0){
-							xpColor = c_yellow;
-							array_push(promotion_tooltip, ["Promotion Possible", [xx+335, yy+64, xx+385, yy+85]]);
-						}
-						// Draw texts with the defined colors
-						draw_set_color(hpColor);
-						draw_text(hpText[0], hpText[1], hpText[2]);
-						draw_set_color(xpColor);
-						draw_text(xpText[0], xpText[1], xpText[2]);
-					}else{
-						draw_set_color(hpColor);
-						draw_text(hpText[0], hpText[1], hpText[2]);
+
+				// Define text positions and values
+				var hpText = [xx+240+8, yy+66, string_hash_to_newline(string(temp3))]; // HP
+				var xpText = [xx+330+8, yy+66, string_hash_to_newline(string(temp4))]; // XP
+				// Define colors
+				var hpColor = c_gray;
+				var xpColor = c_gray;
+				var specialismColor = c_gray;
+				// Check conditions and set colors
+				if (man[sel] == "man"){
+					if (ma_promote[sel] >= 10){
+						hpColor = c_red;
+						array_push(health_tooltip, ["Critical Health State! Bionic augmentation is required!", [xx+250, yy+64, xx+300, yy+85]]);
+					}else if (ma_promote[sel] > 0){
+						xpColor = c_yellow;
+						array_push(promotion_tooltip, ["Promotion Possible", [xx+335, yy+64, xx+385, yy+85]]);
 					}
-					if (unit_specialism_option){
-						if (unit.technology>=35){	//if unit has techmarine potential
-							specialismColor = c_red;
-						} else if (unit.psionic>7){	//if unit has librarian potential
-							specialismColor = c_aqua;
-						}else if (unit.piety>=35 && unit.charisma>=30){	//if unit has chaplain potential
-							specialismColor = c_yellow;
-						}else if (unit.technology>=30 && unit.intelligence>=45){	//if unit has apothecary potential
-							specialismColor = c_white;
-						}
-						draw_set_color(specialismColor);
-						draw_text_transformed(xx+27+8,yy+66,string_hash_to_newline(string(temp1)),name_xr,1,0);
-						draw_text_transformed(xx+27.5+8,yy+66.5,string_hash_to_newline(string(temp1)),name_xr,1,0);
+					draw_set_color(xpColor);
+					draw_text(xpText[0], xpText[1], xpText[2]);
+				}
+				// Draw texts with the defined colors
+				draw_set_color(hpColor);
+				draw_text(hpText[0], hpText[1], hpText[2]);
+				if (unit_specialism_option){
+					if (unit.technology>=35){	//if unit has techmarine potential
+						specialismColor = c_red;
+					} else if (unit.psionic>7){	//if unit has librarian potential
+						specialismColor = c_aqua;
+					}else if (unit.piety>=35 && unit.charisma>=30){	//if unit has chaplain potential
+						specialismColor = c_yellow;
+					}else if (unit.technology>=30 && unit.intelligence>=45){	//if unit has apothecary potential
+						specialismColor = c_white;
 					}
-					else{
-						draw_text_transformed(xx+27+8,yy+66,string_hash_to_newline(string(temp1)),name_xr,1,0);
-						draw_text_transformed(xx+27.5+8,yy+66.5,string_hash_to_newline(string(temp1)),name_xr,1,0);
-					   }
-		        }else if (temp1=="Chapter Master "+string(obj_ini.master_name)){
-		            draw_text_transformed(xx+27+16+8,yy+66,string_hash_to_newline(string(temp1)),name_xr,1,0);
-		            draw_text_transformed(xx+28+16+8,yy+67,string_hash_to_newline(string(temp1)),name_xr,1,0);
-		            draw_sprite(spr_inspect_small,0,xx+27+8,yy+68);
-		        }
+				}
+				// Draw specialism text
+				draw_set_color(specialismColor);
+				draw_text_transformed(xx+27+8,yy+66,string_hash_to_newline(string(temp1)),name_xr,1,0);
+				draw_text_transformed(xx+27.5+8,yy+66.5,string_hash_to_newline(string(temp1)),name_xr,1,0);
+
 		        draw_set_alpha(1);
-	        
 		        draw_set_color(c_gray);
-		        if (temp2=="Mechanicus Vessel") or (temp2=="Terra IV") or (temp2=="=Penitorium=") or (assignment!="none") then draw_set_alpha(0.5);
-		        draw_text_transformed(xx+430+8,yy+66,string_hash_to_newline(string(temp2)),1,1,0);// LOC
+				if (temp2=="Mechanicus Vessel") or (temp2=="Terra IV") or (temp2=="=Penitorium=") or (assignment!="none") then draw_set_alpha(0.5);
+				var truncatedLocation = truncate_string_width(string(temp2), 130); // Truncate the location string to 100 pixels
+				draw_text(xx+430+8,yy+66,truncatedLocation);// LOC
 		        draw_set_alpha(1);
 	        
 		        // ma_lid[i]=0;ma_wid[i]=0;

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -581,7 +581,7 @@ function scr_ui_manage() {
 							}
 						}
         		var_text = string_hash_to_newline(string("Damage Resistance: {0}",cn.temp[118]))
-	        	tooltip_text += string_hash_to_newline(string("CON: {0}%#EXP: {1}%", round(selected_unit.constitution/2), round(selected_unit.experience()/10)));
+	        	tooltip_text += string_hash_to_newline(string("CON: {0}%#XP: {1}%", round(selected_unit.constitution/2), round(selected_unit.experience()/10)));
 	        	x1 = xx+1015;
 	        	y1 = yy+378;
 	        	x2 = x1+string_width(var_text);
@@ -605,7 +605,8 @@ function scr_ui_manage() {
 	        
 	    yy+=77;
 		
-	    var unit_specialism_option=false, spec_tip="", tooltip_set=[];
+	    var unit_specialism_option=false, spec_tip="";
+		var potential_tooltip=[], health_tooltip=[], promotion_tooltip=[];
 		var repetitions=min(man_max,man_see);
 
 		//tooltip text to tell you if a unit is eligible for special roles
@@ -652,7 +653,7 @@ function scr_ui_manage() {
 	                   
 		            temp3=string(round((unit.hp()/unit.max_health())*100))+"% HP";
 	            
-		            temp4=string(ma_exp[sel])+" exp";
+		            temp4=string(ma_exp[sel])+" XP";
 	            
 		            ma_ar="";ma_we1="";ma_we2="";ma_ge="";ma_mb="";ttt=0;
 		            ar_ar=0;ar_we1=0;ar_we2=0;ar_ge=0;ar_mb=0;
@@ -730,48 +731,28 @@ function scr_ui_manage() {
 
 		        unit_specialism_option=false;
 		        spec_tip = "";
+				draw_set_color(c_gray);
+				draw_rectangle(xx+25,yy+64,xx+974,yy+85,1);
 		        if (man[sel]="man"){
-		        	draw_set_color(c_gray);
 		        	if (!is_specialist(unit.role())){
 				        if (unit.technology>=35){
 				        	 //if unit has techmarine potential
-				        	draw_set_color(c_orange);
 				        	unit_specialism_option=true;
 				        	spec_tip = spec_tips[0];
 				        //if unit has librarian potential
 				    	} else if (unit.psionic>7){
 				    		spec_tip = spec_tips[3];
 				    		unit_specialism_option=true;
-				    		draw_set_color(c_aqua);
 				    	}else if (unit.piety>=35) and (unit.charisma>=30){  //if unit has chaplain potential
 				    		spec_tip = spec_tips[2];
 				    		unit_specialism_option=true;
-				    		draw_set_color(c_olive);
 				    	}else if (unit.technology>=30) and (unit.intelligence>=45){ //if unit has apothecary potential
 				    		spec_tip = spec_tips[1];
 				    		unit_specialism_option=true;
-				    		draw_set_color(c_fuchsia);
 				    	}
-			    	} else{
-			    		if (array_contains(["Lexicanum", "Codiciery",obj_ini.role[100,17], string("Chief {0}",obj_ini.role[100,17])], unit.role())){
-			    			draw_set_color(c_blue);
-			    		} else if(array_contains(["Forge Master",obj_ini.role[100][16]],unit.role())){
-			    			draw_set_color(c_maroon);
-			    		} else if(array_contains([obj_ini.role[100][15],"Master of the Apothecarion"],unit.role())){
-			    			draw_set_color(c_red);
-			    		} else if(array_contains([obj_ini.role[100][14],"Master of Sanctity"],unit.role())){
-			    			draw_set_color(c_teal);
-			    		}
 			    	}
-		    	} else {
-		    		draw_set_color(c_gray);
 		    	}
-		    	if (unit_specialism_option){
-		    		array_push(tooltip_set, [spec_tip, [xx+25,yy+64,xx+974,yy+85]]);
-		    		draw_rectangle(xx+25+2,yy+64+2,xx+974-2,yy+85-2,1);
-		    	} else{
-					draw_rectangle(xx+25,yy+64,xx+974,yy+85,1);
-		    	}
+		    	if (unit_specialism_option) then array_push(potential_tooltip, [spec_tip, [xx+25,yy+64,xx+250,yy+85]]);
 
 		        // Squads
 		        var sqi="";
@@ -819,11 +800,48 @@ function scr_ui_manage() {
 				}
 	        
 		        if (temp1!="Chapter Master "+string(obj_ini.master_name)){
-		            if (man[sel]=="man") and (ma_promote[sel]>0) then draw_set_color(c_yellow);
-		            if (man[sel]=="man") and (ma_promote[sel]>=10) then draw_set_color(c_red);
-		            draw_text_transformed(xx+27+8,yy+66,string_hash_to_newline(string(temp1)),name_xr,1,0);
-		            draw_text_transformed(xx+28+8,yy+67,string_hash_to_newline(string(temp1)),name_xr,1,0);
-		            draw_set_color(c_gray);
+					// Define text positions and values
+					var hpText = [xx+240+8, yy+66, string_hash_to_newline(string(temp3))]; // HP
+					var xpText = [xx+330+8, yy+66, string_hash_to_newline(string(temp4))]; // XP
+					// Define colors
+					var hpColor = c_gray;
+					var xpColor = c_gray;
+					// Check conditions and set colors
+					if (man[sel] == "man"){
+						if (ma_promote[sel] >= 10){
+							hpColor = c_red;
+							array_push(health_tooltip, ["Critical Health State! Bionic augmentation is required!", [xx+270, yy+64, xx+295, yy+85]]);
+						}else if (ma_promote[sel] > 0){
+							xpColor = c_yellow;
+							array_push(promotion_tooltip, ["Promotion Possible", [xx+335, yy+64, xx+385, yy+85]]);
+						}
+						// Draw texts with the defined colors
+						draw_set_color(hpColor);
+						draw_text(hpText[0], hpText[1], hpText[2]);
+						draw_set_color(xpColor);
+						draw_text(xpText[0], xpText[1], xpText[2]);
+					}else{
+						draw_set_color(hpColor);
+						draw_text(hpText[0], hpText[1], hpText[2]);
+					}
+					if (unit_specialism_option){
+						if (unit.technology>=35){	//if unit has techmarine potential
+							specialismColor = c_red;
+						} else if (unit.psionic>7){	//if unit has librarian potential
+							specialismColor = c_aqua;
+						}else if (unit.piety>=35 && unit.charisma>=30){	//if unit has chaplain potential
+							specialismColor = c_yellow;
+						}else if (unit.technology>=30 && unit.intelligence>=45){	//if unit has apothecary potential
+							specialismColor = c_white;
+						}
+						draw_set_color(specialismColor);
+						draw_text_transformed(xx+27+8,yy+66,string_hash_to_newline(string(temp1)),name_xr,1,0);
+						draw_text_transformed(xx+27.5+8,yy+66.5,string_hash_to_newline(string(temp1)),name_xr,1,0);
+					}
+					else{
+						draw_text_transformed(xx+27+8,yy+66,string_hash_to_newline(string(temp1)),name_xr,1,0);
+						draw_text_transformed(xx+27.5+8,yy+66.5,string_hash_to_newline(string(temp1)),name_xr,1,0);
+					   }
 		        }else if (temp1=="Chapter Master "+string(obj_ini.master_name)){
 		            draw_text_transformed(xx+27+16+8,yy+66,string_hash_to_newline(string(temp1)),name_xr,1,0);
 		            draw_text_transformed(xx+28+16+8,yy+67,string_hash_to_newline(string(temp1)),name_xr,1,0);
@@ -832,8 +850,6 @@ function scr_ui_manage() {
 		        draw_set_alpha(1);
 	        
 		        draw_set_color(c_gray);
-		        draw_text_transformed(xx+240+8,yy+66,string_hash_to_newline(string(temp3)),1,1,0);// HP
-		        draw_text_transformed(xx+330+8,yy+66,string_hash_to_newline(string(temp4)),1,1,0);// EXP
 		        if (temp2=="Mechanicus Vessel") or (temp2=="Terra IV") or (temp2=="=Penitorium=") or (assignment!="none") then draw_set_alpha(0.5);
 		        draw_text_transformed(xx+430+8,yy+66,string_hash_to_newline(string(temp2)),1,1,0);// LOC
 		        draw_set_alpha(1);
@@ -1110,13 +1126,19 @@ function scr_ui_manage() {
 			            }
 			        }
 			    }
-			    //draws hover overs for specialist potential
-			    for (var i=0;i<array_length(tooltip_set);i++){
-			    	if (point_in_rectangle(mouse_x, mouse_y, tooltip_set[i][1][0],tooltip_set[i][1][1],tooltip_set[i][1][2],tooltip_set[i][1][3])){
-			    		tooltip_draw(tooltip_set[i][0])
-			    	}
-			    }
-		    
+			    //draws hover over tooltips
+				function gen_tooltip(tooltip_array) {
+					for (var i = 0; i < array_length(tooltip_array); i++) {
+						var tooltip = tooltip_array[i];
+						if (point_in_rectangle(mouse_x, mouse_y, tooltip[1][0], tooltip[1][1], tooltip[1][2], tooltip[1][3])) {
+							tooltip_draw(tooltip[0]);
+						}
+					}
+				}
+				gen_tooltip(potential_tooltip);
+				gen_tooltip(promotion_tooltip);
+				gen_tooltip(health_tooltip);
+
 			    yy-=8;
 
 		    	draw_unit_buttons([xx+1281,yy+608],"Select All");

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -752,7 +752,7 @@ function scr_ui_manage() {
 				    	}
 			    	}
 		    	}
-		    	if (unit_specialism_option) then array_push(potential_tooltip, [spec_tip, [xx+35.5,yy+64,xx+211.5,yy+85]]);
+		    	if (unit_specialism_option) then array_push(potential_tooltip, [spec_tip, [xx+232,yy+64,xx+246,yy+85]]);
 
 		        // Squads
 		        var sqi="";
@@ -799,14 +799,12 @@ function scr_ui_manage() {
 					if ((string_width(string_hash_to_newline(temp1))*name_xr)>184-8) then name_xr-=0.05;
 				}
 
-				// Define text positions and values
 				var hpText = [xx+240+8, yy+66, string_hash_to_newline(string(temp3))]; // HP
 				var xpText = [xx+330+8, yy+66, string_hash_to_newline(string(temp4))]; // XP
-				// Define colors
 				var hpColor = c_gray;
 				var xpColor = c_gray;
-				var specialismColor = c_gray;
-				// Check conditions and set colors
+				var specialismColors = [];
+				// Draw XP value and set up health color
 				if (man[sel] == "man"){
 					if (ma_promote[sel] >= 10){
 						hpColor = c_red;
@@ -815,30 +813,31 @@ function scr_ui_manage() {
 						xpColor = c_yellow;
 						array_push(promotion_tooltip, ["Promotion Possible", [xx+335, yy+64, xx+385, yy+85]]);
 					}
-					draw_set_color(xpColor);
-					draw_text(xpText[0], xpText[1], xpText[2]);
+					draw_text_color(xpText[0], xpText[1], xpText[2], xpColor, xpColor, xpColor, xpColor, 1);
 				}
-				// Draw texts with the defined colors
-				draw_set_color(hpColor);
-				draw_text(hpText[0], hpText[1], hpText[2]);
+				// Draw the health value with the defined colors
+				draw_text_color(hpText[0], hpText[1], hpText[2], hpColor, hpColor, hpColor, hpColor, 1);
+
+				// Handle potential indication
 				if (unit_specialism_option){
 					if (unit.technology>=35){	//if unit has techmarine potential
-						specialismColor = c_red;
+						specialismColors = [c_dkgray, c_red];
 					} else if (unit.psionic>7){	//if unit has librarian potential
-						specialismColor = c_aqua;
+						specialismColors = [c_white, c_aqua];
 					}else if (unit.piety>=35 && unit.charisma>=30){	//if unit has chaplain potential
-						specialismColor = c_yellow;
+						specialismColors = [c_black, c_yellow];
 					}else if (unit.technology>=30 && unit.intelligence>=45){	//if unit has apothecary potential
-						specialismColor = c_white;
+						specialismColors = [c_red, c_white];
 					}
+					draw_circle_colour(xx+238, yy+73, 6, specialismColors[0],specialismColors[1], 0);
 				}
-				// Draw specialism text
-				draw_set_color(specialismColor);
+
+				// Draw the name
+		        draw_set_color(c_gray);
 				draw_text_transformed(xx+27+8,yy+66,string_hash_to_newline(string(temp1)),name_xr,1,0);
 				draw_text_transformed(xx+27.5+8,yy+66.5,string_hash_to_newline(string(temp1)),name_xr,1,0);
 
-		        draw_set_alpha(1);
-		        draw_set_color(c_gray);
+				// Draw current location
 				if (temp2=="Mechanicus Vessel") or (temp2=="Terra IV") or (temp2=="=Penitorium=") or (assignment!="none") then draw_set_alpha(0.5);
 				var truncatedLocation = truncate_string_width(string(temp2), 130); // Truncate the location string to 100 pixels
 				draw_text(xx+430+8,yy+66,truncatedLocation);// LOC

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -610,9 +610,9 @@ function scr_ui_manage() {
 
 		//tooltip text to tell you if a unit is eligible for special roles
 		var spec_tips = [string("{0} Potential",obj_ini.role[100][16]),		
-						string("{0} potential",obj_ini.role[100][15]),
-						string("{0} potential",obj_ini.role[100][14]),
-						"Librarium potential"];
+						string("{0} Potential",obj_ini.role[100][15]),
+						string("{0} Potential",obj_ini.role[100][14]),
+						"Librarium Potential"];
 		var assignment ="none"
 	    
 	    if (!obj_controller.view_squad){

--- a/scripts/scr_ui_popup/scr_ui_popup.gml
+++ b/scripts/scr_ui_popup/scr_ui_popup.gml
@@ -1,9 +1,9 @@
-function tooltip_draw(tooltip="", max_width=300, coords=[mouse_x+24,mouse_y+24], text_color=c_gray, font=fnt_40k_14, header="", header_font=fnt_40k_14b){
+function tooltip_draw(tooltip="", max_width=300, coords=[mouse_x+20,mouse_y+20], text_color=c_gray, font=fnt_40k_14, header="", header_font=fnt_40k_14b){
 	draw_set_halign(fa_left);
 	draw_set_alpha(1)
 	// Calculate padding and rectangle size
-	static text_padding_x = 4;
-	static text_padding_y = 4;
+	static text_padding_x = 6;
+	static text_padding_y = 6;
 	// Convert hash to newline in strings
 	header = string_hash_to_newline(string(header));
 	tooltip = string_hash_to_newline(string(tooltip));
@@ -27,9 +27,17 @@ function tooltip_draw(tooltip="", max_width=300, coords=[mouse_x+24,mouse_y+24],
 	// Get view coordinates
 	var xx = __view_get(e__VW.XView, 0);
 	var yy = __view_get(e__VW.YView, 0);
-	// Define tooltip position and clamp it to view
-	var rect_x = clamp(coords[0], xx + DEFAULT_TOOLTIP_VIEW_OFFSET, xx + __view_get(e__VW.WView, 0) - rect_w - DEFAULT_TOOLTIP_VIEW_OFFSET);
-	var rect_y = clamp(coords[1], yy + DEFAULT_TOOLTIP_VIEW_OFFSET, yy + __view_get(e__VW.HView, 0) - rect_h - DEFAULT_TOOLTIP_VIEW_OFFSET);
+	// Define tooltip position
+	var rect_x = coords[0];
+	var rect_y = coords[1];
+	// Check if the tooltip goes over the right part of the screen and flip left if so
+	if (rect_x + rect_w > xx + __view_get(e__VW.WView, 0)) {
+		rect_x = coords[0] - rect_w - 40;
+	}
+	// Check if the tooltip goes over the bottom part of the screen and flip up if so
+	if (rect_y + rect_h > yy + __view_get(e__VW.HView, 0)) {
+		rect_y = coords[1] - rect_h - 40;
+	}
 	// Draw the tooltip rectangle with an outline
 	draw_rectangle_colour(rect_x, rect_y, rect_w + rect_x, rect_h + rect_y, c_black, c_black, c_black, c_black, 0);
 	draw_rectangle_colour(rect_x + 1, rect_y + 1, rect_w + rect_x - 1, rect_h + rect_y - 1, c_gray, c_gray, c_gray, c_gray, 1);


### PR DESCRIPTION
### Done:
1. A new script to replace characters that get beyond a set string width with "...".
2. Rework how potential is displayed. ~~Now marine names change color~~ now there are little role colored spheres, with no line color changes. These were hard to see and hard to distinguish to which unit they are attached. I'm not 100% happy with the current approach, but I think it's okay. 
3. Rework how possible promotion and critical health are displayed. Promotions recolor XP value, critical health recolors HP value.
3.1 Added tooltips to these values, when there is an active interaction.
4. Used the new script to truncate the current soldier location if it's too long.
5. Refactored some of the code related to the above systems.
6. [Replaced tooltip clamping with flipping.](https://github.com/OH296/ChapterMaster/pull/16/commits/dff9f2915476c31c65e2bc82ab43b6378d3a7e8f)
7. Typo fixes and minor adjustment of elements placement on the shop screen.
8. Fix champions deselecting working properly but not returning back if you select them on the drop screen.

### TODO:
- [x] Maybe replace name recoloring with a rectangle around the name. Or a small colored circle after the name.